### PR TITLE
Include GitHub action on push and pr

### DIFF
--- a/.github/workflows/test-on-push-and-pr.yml
+++ b/.github/workflows/test-on-push-and-pr.yml
@@ -1,0 +1,20 @@
+name: test-on-push-and-pr
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+    - name: Run 'pr' target
+      run: make pr

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ dev: init test
 
 # Verifications to run before sending a pull request
 .PHONY: pr
-pr: dev test-smoke
+pr: build dev test-smoke
 
 .PHONY: clean
 clean:

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -20,7 +20,6 @@ if test "${current_path#*$node_modules_path}" != "$current_path" || [ "$BUILD" !
     deps_path="$current_path/../deps"
 
     # Clean up source dependencies
-    rm -rf "$deps_path"/patches
-    rm -rf "$deps_path"/aws-lambda-cpp*
-    rm -rf "$deps_path"/curl*
+    rm -rf "$deps_path"/aws-lambda-cpp*[^gz]$
+    rm -rf "$deps_path"/curl*[^gz]$
 fi

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -20,6 +20,7 @@ if test "${current_path#*$node_modules_path}" != "$current_path" || [ "$BUILD" !
     deps_path="$current_path/../deps"
 
     # Clean up source dependencies
+    rm -rf "$deps_path"/patches
     rm -rf "$deps_path"/aws-lambda-cpp*[^gz]$
     rm -rf "$deps_path"/curl*[^gz]$
 fi

--- a/test/integration/codebuild-local/codebuild_build.sh
+++ b/test/integration/codebuild-local/codebuild_build.sh
@@ -95,7 +95,7 @@ then
     exit 1
 fi
 
-docker_command="docker run -it "
+docker_command="docker run "
 if isOSWindows
 then
     docker_command+="-v //var/run/docker.sock:/var/run/docker.sock -e "


### PR DESCRIPTION
*Description of changes:*
* Added GitHub workflow to run the required checks on push and pr
* Added `build` prerequisite target to `pr` target
* Removed unnecessary -it option from codebuild_build.sh because it was causing tty error when running the GitHub action
* Refactored `postinstall` script to only clean up the uncompressed dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
