### PR TITLE
Fix errors issues

### DIFF
--- a/src/Errors/index.ts
+++ b/src/Errors/index.ts
@@ -81,17 +81,18 @@ export const toFormatted = (error: unknown): string => {
  * user-provided enumerable properties.
  */
 function _withEnumerableProperties(error: any) {
-  if (error instanceof ExtendedError) {
+  if (error instanceof Error) {
+    const extendedError: ExtendedError = <ExtendedError>(<any>error);
     const ret: any = Object.assign(
       {
-        errorType: error.name,
-        errorMessage: error.message,
-        code: error.code,
+        errorType: extendedError.name,
+        errorMessage: extendedError.message,
+        code: extendedError.code,
       },
-      error
+      extendedError
     );
-    if (typeof error.stack == "string") {
-      ret.stack = error.stack.split("\n");
+    if (typeof extendedError.stack == "string") {
+      ret.stack = extendedError.stack.split("\n");
     }
     return ret;
   } else {

--- a/src/utils/UserFunction.ts
+++ b/src/utils/UserFunction.ts
@@ -101,7 +101,7 @@ function _loadUserApp(
     return _tryRequire(appRoot, moduleRoot, module);
   } catch (e) {
     if (e instanceof SyntaxError) {
-      throw new UserCodeSyntaxError(e.message);
+      throw new UserCodeSyntaxError(<any>e);
     } else if (e.code !== undefined && e.code === "MODULE_NOT_FOUND") {
       throw new ImportModuleError(e);
     } else {

--- a/test/unit/Errors/Errors.test.ts
+++ b/test/unit/Errors/Errors.test.ts
@@ -16,7 +16,21 @@ class CircularError extends Error {
   }
 }
 
-describe("Formatting Error Logging", () => {
+class ExtendedError extends Error {
+  code?: number;
+  customProperty?: string;
+
+  constructor(message?: string) {
+    super(message);
+
+    this.name = "ExtendedError";
+    this.stack = "ExtendedErrorStack";
+    this.code = 100;
+    this.customProperty = "ExtendedErrorCustomProperty";
+  }
+}
+
+describe("Formatting CircularError Logging", () => {
   it("should fall back to a minimal error format when an exception occurs", () => {
     const error = new CircularError("custom message");
     error.backlink = error;
@@ -26,6 +40,22 @@ describe("Formatting Error Logging", () => {
     loggedError.should.have.property("errorMessage", "custom message");
     loggedError.should.have.property("trace");
     loggedError.trace.length.should.be.aboveOrEqual(1);
+  });
+});
+
+describe("Formatting Error Logging", () => {
+  it("should fall back to an extended error format when an exception occurs", () => {
+    const error = new ExtendedError("custom message");
+
+    const loggedError = JSON.parse(Errors.toFormatted(error).trim());
+    loggedError.should.have.property("errorType", "ExtendedError");
+    loggedError.should.have.property("errorMessage", "custom message");
+    loggedError.should.have.property("stack", ["ExtendedErrorStack"]);
+    loggedError.should.have.property("code", 100);
+    loggedError.should.have.property(
+      "customProperty",
+      "ExtendedErrorCustomProperty"
+    );
   });
 });
 


### PR DESCRIPTION
*Description of changes:*
- Fixed issue when if statement was checking for `ExtendedError`, but it should have checked for `Error`. That if statement was never passed, so the logs of the error were not complete.
- Added a test for the above fix. Before there was a test that checked the logging error behavior, but it checked with a `CircularError`, which was only testing the case when the `try` [statement](https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/main/src/Errors/index.ts#L68) failed. Added a test that would test the behavior for when the `try` statement succeeds (i.e. testing the [_withEnumerableProperties](https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/main/src/Errors/index.ts#L83) method).
- When facing a `SyntaxError` only the message of the error would get logged. Changed it so that the whole error would get logged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
