### PR TITLE
tar using --no-same-owner

### DIFF
--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -20,8 +20,8 @@ else
     . ./versions
 
     # unpack dependencies
-    tar xzf ./curl-$CURL_VERSION.tar.gz && \
-    tar xzf ./aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE.tar.gz
+    tar xzf ./curl-$CURL_VERSION.tar.gz --no-same-owner && \
+    tar xzf ./aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE.tar.gz --no-same-owner
 
     (
         # Build Curl

--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -25,6 +25,7 @@ wget -c https://github.com/awslabs/aws-lambda-cpp/archive/v$AWS_LAMBDA_CPP_RELEA
     patch -p1 < ../patches/aws-lambda-cpp-add-content-type.patch
 )
 
+
 # Pack again and remove the folder
-tar -czvf aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE.tar.gz aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE && \
+tar -czvf aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE.tar.gz aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE --no-same-owner && \
   rm -rf aws-lambda-cpp-$AWS_LAMBDA_CPP_RELEASE


### PR DESCRIPTION
*Issue #, if available:*
#10 

*Description of changes:*
Run tar using `--no-same-owner`. This works around permissions issues when trying to install aws-lambda-ric on CI pipelines. It also maintains parity with https://github.com/aws/aws-lambda-python-runtime-interface-client/pull/39

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
