### PR TITLE
Use python3.8 in al2 integ tests

### DIFF
--- a/test/integration/docker/Dockerfile.echo.amazonlinux
+++ b/test/integration/docker/Dockerfile.echo.amazonlinux
@@ -10,7 +10,7 @@ FROM amazonlinux:${DISTRO_VERSION} AS node-amazonlinux
 ARG RUNTIME_VERSION
 ARG DISTRO_VERSION
 # Install Py3 required to build Node16+
-RUN if [[ "${DISTRO_VERSION}" == "2" ]] ; then amazon-linux-extras install python3 ; fi
+RUN if [[ "${DISTRO_VERSION}" == "2" ]] ; then amazon-linux-extras install python3.8 && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 ; fi
 # Install NodeJS
 RUN curl -sL https://rpm.nodesource.com/setup_${RUNTIME_VERSION}.x | bash - && \
     yum install -y nodejs


### PR DESCRIPTION
*Description of changes:*
`amazon-linux-extras` does not contain python3 topic out of the box for aarch64 arch because:
> Topic python3 has end-of-support date of 2018-08-22

However, both x86 and aarch64 contain python3.8, hence setting python3.8 as python3 default in AL2 integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
