### PR TITLE
Remove unrecognized --disable-websockets option

### DIFF
--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -68,7 +68,6 @@ else
                 --disable-unix-sockets \
                 --disable-verbose \
                 --disable-versioned-symbols \
-                --disable-websockets \
                 --with-pic \
                 --without-brotli \
                 --without-ca-bundle \


### PR DESCRIPTION
_Description of changes:_

Remove unrecognized `--disable-websockets` option
```
#4 31.41 configure: WARNING: unrecognized options: --disable-websockets
```
_Target (OCI, Managed Runtime, both):_
OCI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
