### PR TITLE
Update Distros and integration tests

### DIFF
--- a/test/integration/codebuild/buildspec.os.alpine.1.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.1.yml
@@ -14,7 +14,6 @@ batch:
       env:
         variables:
           DISTRO_VERSION:
-            - "3.14"
             - "3.15"
             - "3.16"
           RUNTIME_VERSION:

--- a/test/integration/codebuild/buildspec.os.alpine.2.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.2.yml
@@ -16,7 +16,6 @@ batch:
       env:
         variables:
           DISTRO_VERSION:
-            - "3.14"
             - "3.15"
             - "3.16"
           RUNTIME_VERSION:

--- a/test/integration/codebuild/buildspec.os.debian.2.yml
+++ b/test/integration/codebuild/buildspec.os.debian.2.yml
@@ -1,0 +1,110 @@
+version: 0.2
+
+env:
+  variables:
+    OS_DISTRIBUTION: debian
+    NPX_BINARY_LOCATION: "/usr/local/bin/npx"
+batch:
+  build-matrix:
+    static:
+      ignore-failure: false
+      env:
+        privileged-mode: true
+    dynamic:
+      env:
+        variables:
+          DISTRO_VERSION:
+            - "bookworm"
+          RUNTIME_VERSION:
+            - "16"
+            - "18"
+phases:
+  pre_build:
+    commands:
+      - export IMAGE_TAG="nodejs-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
+      - echo "Extracting and including the Runtime Interface Emulator"
+      - SCRATCH_DIR=".scratch"
+      - mkdir "${SCRATCH_DIR}"
+      - ARCHITECTURE=$(arch)
+      - >
+        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+            RIE="aws-lambda-rie"
+        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+            RIE="aws-lambda-rie-arm64"
+        else
+            echo "Architecture $ARCHITECTURE is not currently supported."
+            exit 1
+        fi
+      - tar -xvf test/integration/resources/${RIE}.tar.gz --directory "${SCRATCH_DIR}"
+      - >
+        cp "test/integration/docker/Dockerfile.echo.${OS_DISTRIBUTION}" \
+          "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        echo "COPY ${SCRATCH_DIR}/${RIE} /usr/bin/${RIE}" >> \
+          "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
+      - >
+        echo "RUN apt-get update && apt-get install -y curl" >> \
+          "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - echo "Building image ${IMAGE_TAG}"
+      - >
+        docker build . \
+          -f "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp" \
+          -t "${IMAGE_TAG}" \
+          --build-arg RUNTIME_VERSION="${RUNTIME_VERSION}" \
+          --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
+  build:
+    commands:
+      - set -x
+      - echo "Running Image ${IMAGE_TAG}"
+      - docker network create "${OS_DISTRIBUTION}-network"
+      - >
+        docker run \
+          --detach \
+          --name "${OS_DISTRIBUTION}-app" \
+          --network "${OS_DISTRIBUTION}-network" \
+          --entrypoint="" \
+          "${IMAGE_TAG}" \
+          sh -c "/usr/bin/${RIE} ${NPX_BINARY_LOCATION} aws-lambda-ric index.handler"
+      - sleep 2
+      - >
+        docker run \
+          --name "${OS_DISTRIBUTION}-tester" \
+          --env "TARGET=${OS_DISTRIBUTION}-app" \
+          --network "${OS_DISTRIBUTION}-network" \
+          --entrypoint="" \
+          "${IMAGE_TAG}" \
+          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
+      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
+      - expected='success'
+      - |
+        echo "Response: ${actual}"
+        if [[ "$actual" != "$expected" ]]; then
+          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
+          exit -1
+        fi
+    finally:
+      - |
+          echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"
+          echo
+          docker logs "${OS_DISTRIBUTION}-app" || true
+          echo
+          echo "---------------------------------------------------"
+          echo "--------Container Logs: ${OS_DISTRIBUTION}-tester--------"
+          echo
+          docker logs "${OS_DISTRIBUTION}-tester" || true
+          echo
+          echo "---------------------------------------------------"
+      - echo "Cleaning up..."
+      - docker stop "${OS_DISTRIBUTION}-app" || true
+      - docker rm --force "${OS_DISTRIBUTION}-app" || true
+      - docker stop "${OS_DISTRIBUTION}-tester" || true
+      - docker rm --force "${OS_DISTRIBUTION}-tester" || true
+      - docker network rm "${OS_DISTRIBUTION}-network" || true

--- a/test/integration/docker/Dockerfile.echo.amazonlinux
+++ b/test/integration/docker/Dockerfile.echo.amazonlinux
@@ -12,9 +12,16 @@ ARG DISTRO_VERSION
 # Install Py3 required to build Node16+
 RUN if [[ "${DISTRO_VERSION}" == "2" ]] ; then amazon-linux-extras install python3.8 && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 ; fi
 # Install NodeJS
-RUN curl -sL https://rpm.nodesource.com/setup_${RUNTIME_VERSION}.x | bash - && \
-    yum install -y nodejs
-
+RUN if [[ "${RUNTIME_VERSION}" == "14" ]]; then \
+    yum install -y tar gzip xz && \
+    AARCH="$([[ "$(arch)" == "x86_64" ]] && echo "x64" || echo "arm64")" && \
+    NODE_URL="https://nodejs.org/download/release/v14.21.3/node-v14.21.3-linux-$AARCH.tar.xz" && \
+    curl -fL "$NODE_URL" | tar -C /usr --strip-components 1 -xJf - && \
+    yum clean all -q && rm -rf /var/cache/yum ; \
+else \
+    yum install https://rpm.nodesource.com/pub_${RUNTIME_VERSION}.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y && \
+    yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1s ; \
+fi
 
 # Stage 2 - build function and dependencies
 FROM node-amazonlinux AS build-image


### PR DESCRIPTION
_Description of changes:_

1. Replace deprecated nodesource install scripts for AmazonLinux integration tests:
> Installation Scripts: The installation scripts setup_XX.x are no longer supported and are not needed anymore, as the installation process is straightforward for any RPM and DEB distro.

2. Remove Alpine3.14 from integration tests since it has reached EOL
3. Add Debian bookworm to integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


_Target (OCI, Managed Runtime, both):_
OCI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
