### PR TITLE
Clean up images after running integ tests

### DIFF
--- a/test/integration/codebuild/buildspec.os.alpine.1.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.1.yml
@@ -110,3 +110,4 @@ phases:
       - docker stop "${OS_DISTRIBUTION}-tester" || true
       - docker rm --force "${OS_DISTRIBUTION}-tester" || true
       - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/codebuild/buildspec.os.alpine.2.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.2.yml
@@ -102,3 +102,4 @@ phases:
       - docker stop "${OS_DISTRIBUTION}-tester" || true
       - docker rm --force "${OS_DISTRIBUTION}-tester" || true
       - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
+++ b/test/integration/codebuild/buildspec.os.amazonlinux.2.yml
@@ -106,3 +106,4 @@ phases:
       - docker stop "${OS_DISTRIBUTION}-tester" || true
       - docker rm --force "${OS_DISTRIBUTION}-tester" || true
       - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/codebuild/buildspec.os.amazonlinux.2023.yml
+++ b/test/integration/codebuild/buildspec.os.amazonlinux.2023.yml
@@ -105,3 +105,4 @@ phases:
       - docker stop "${OS_DISTRIBUTION}-tester" || true
       - docker rm --force "${OS_DISTRIBUTION}-tester" || true
       - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/codebuild/buildspec.os.centos.yml
+++ b/test/integration/codebuild/buildspec.os.centos.yml
@@ -108,3 +108,4 @@ phases:
       - docker stop "${OS_DISTRIBUTION}-tester" || true
       - docker rm --force "${OS_DISTRIBUTION}-tester" || true
       - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/codebuild/buildspec.os.debian.2.yml
+++ b/test/integration/codebuild/buildspec.os.debian.2.yml
@@ -108,3 +108,4 @@ phases:
       - docker stop "${OS_DISTRIBUTION}-tester" || true
       - docker rm --force "${OS_DISTRIBUTION}-tester" || true
       - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/codebuild/buildspec.os.debian.yml
+++ b/test/integration/codebuild/buildspec.os.debian.yml
@@ -110,3 +110,4 @@ phases:
       - docker stop "${OS_DISTRIBUTION}-tester" || true
       - docker rm --force "${OS_DISTRIBUTION}-tester" || true
       - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/codebuild/buildspec.os.ubuntu.1.yml
+++ b/test/integration/codebuild/buildspec.os.ubuntu.1.yml
@@ -108,3 +108,4 @@ phases:
       - docker stop "${OS_DISTRIBUTION}-tester" || true
       - docker rm --force "${OS_DISTRIBUTION}-tester" || true
       - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/codebuild/buildspec.os.ubuntu.2.yml
+++ b/test/integration/codebuild/buildspec.os.ubuntu.2.yml
@@ -106,3 +106,4 @@ phases:
       - docker stop "${OS_DISTRIBUTION}-tester" || true
       - docker rm --force "${OS_DISTRIBUTION}-tester" || true
       - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true


### PR DESCRIPTION
_Description of changes:_

Clean up images after running integ tests otherwise, when adding new runtimes and/or distros, the host runs out of space.

_Target (OCI, Managed Runtime, both):_
OCI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
