### PR TITLE
Add Alpine3.17,3.18 remove 3.15 for integ tests

### DIFF
--- a/.github/workflows/test-on-push-and-pr.yml
+++ b/.github/workflows/test-on-push-and-pr.yml
@@ -12,10 +12,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '16'
     - name: Run 'pr' target
       run: make pr
 
@@ -24,10 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '16'
     - name: Run alpine integration tests
       run: DISTRO=alpine make test-integ
 
@@ -36,10 +28,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '16'
     - name: Run amazonlinux integration tests
       run: DISTRO=amazonlinux make test-integ
 
@@ -48,10 +36,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '16'
     - name: Run centos integration tests
       run: DISTRO=centos make test-integ
 
@@ -60,10 +44,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '16'
     - name: Run debian integration tests
       run: DISTRO=debian make test-integ
 
@@ -72,9 +52,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '16'
     - name: Run ubuntu integration tests
       run: DISTRO=ubuntu make test-integ

--- a/test/integration/codebuild/buildspec.os.alpine.1.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.1.yml
@@ -14,7 +14,6 @@ batch:
       env:
         variables:
           DISTRO_VERSION:
-            - "3.15"
             - "3.16"
           RUNTIME_VERSION:
             - "14"

--- a/test/integration/codebuild/buildspec.os.alpine.2.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.2.yml
@@ -16,7 +16,6 @@ batch:
       env:
         variables:
           DISTRO_VERSION:
-            - "3.15"
             - "3.16"
           RUNTIME_VERSION:
             - "14"

--- a/test/integration/codebuild/buildspec.os.alpine.3.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.3.yml
@@ -1,0 +1,112 @@
+version: 0.2
+
+env:
+  variables:
+    OS_DISTRIBUTION: alpine
+    NPX_BINARY_LOCATION: "/usr/local/bin/npx"
+batch:
+  build-matrix:
+    static:
+      ignore-failure: false
+      env:
+        privileged-mode: true
+    dynamic:
+      env:
+        variables:
+          DISTRO_VERSION:
+            - "3.17"
+            - "3.18"
+          RUNTIME_VERSION:
+            - "16"
+            - "18"
+phases:
+  pre_build:
+    commands:
+      - export IMAGE_TAG="nodejs-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
+      - echo "Extracting and including the Runtime Interface Emulator"
+      - SCRATCH_DIR=".scratch"
+      - mkdir "${SCRATCH_DIR}"
+      - ARCHITECTURE=$(arch)
+      - >
+        if [[ "$ARCHITECTURE" == "x86_64" ]]; then
+            RIE="aws-lambda-rie"
+        elif [[ "$ARCHITECTURE" == "aarch64" ]]; then
+            RIE="aws-lambda-rie-arm64"
+        else
+            echo "Architecture $ARCHITECTURE is not currently supported."
+            exit 1
+        fi
+      - tar -xvf test/integration/resources/${RIE}.tar.gz --directory "${SCRATCH_DIR}"
+      - >
+        cp "test/integration/docker/Dockerfile.echo.${OS_DISTRIBUTION}" \
+          "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        echo "RUN apk add curl" >> \
+          "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        echo "COPY ${SCRATCH_DIR}/${RIE} /usr/bin/${RIE}" >> \
+          "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
+      - echo "Building image ${IMAGE_TAG}"
+      - >
+        docker build . \
+          -f "${SCRATCH_DIR}/Dockerfile.echo.${OS_DISTRIBUTION}.tmp" \
+          -t "${IMAGE_TAG}" \
+          --build-arg RUNTIME_VERSION="${RUNTIME_VERSION}" \
+          --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
+  build:
+    commands:
+      - set -x
+      - echo "Running Image ${IMAGE_TAG}"
+      - docker network create "${OS_DISTRIBUTION}-network"
+      - >
+        docker run \
+          --detach \
+          --name "${OS_DISTRIBUTION}-app" \
+          --network "${OS_DISTRIBUTION}-network" \
+          --entrypoint="" \
+          "${IMAGE_TAG}" \
+          sh -c "/usr/bin/${RIE} ${NPX_BINARY_LOCATION} aws-lambda-ric index.handler"
+      - sleep 2
+      - >
+        docker run \
+          --name "${OS_DISTRIBUTION}-tester" \
+          --env "TARGET=${OS_DISTRIBUTION}-app" \
+          --network "${OS_DISTRIBUTION}-network" \
+          --entrypoint="" \
+          "${IMAGE_TAG}" \
+          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
+      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
+      - expected='success'
+      - |
+        echo "Response: ${actual}"
+        if [[ "$actual" != "$expected" ]]; then
+          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
+          exit -1
+        fi
+    finally:
+      - |
+          echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"
+          echo
+          docker logs "${OS_DISTRIBUTION}-app" || true
+          echo
+          echo "---------------------------------------------------"
+          echo "--------Container Logs: ${OS_DISTRIBUTION}-tester--------"
+          echo
+          docker logs "${OS_DISTRIBUTION}-tester" || true
+          echo
+          echo "---------------------------------------------------"
+      - echo "Cleaning up..."
+      - docker stop "${OS_DISTRIBUTION}-app" || true
+      - docker rm --force "${OS_DISTRIBUTION}-app" || true
+      - docker stop "${OS_DISTRIBUTION}-tester" || true
+      - docker rm --force "${OS_DISTRIBUTION}-tester" || true
+      - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/codebuild/buildspec.os.alpine.4.yml
+++ b/test/integration/codebuild/buildspec.os.alpine.4.yml
@@ -1,0 +1,104 @@
+version: 0.2
+
+env:
+  variables:
+    OS_DISTRIBUTION: alpine
+    NODE_BINARY_LOCATION: "/usr/local/bin/node"
+    NPX_BINARY_LOCATION: "/usr/local/bin/npx"
+batch:
+  build-matrix:
+    static:
+      ignore-failure: false
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: true
+    dynamic:
+      env:
+        variables:
+          DISTRO_VERSION:
+            - "3.17"
+            - "3.18"
+          RUNTIME_VERSION:
+            - "16"
+            - "18"
+phases:
+  pre_build:
+    commands:
+      - export IMAGE_TAG="nodejs-${OS_DISTRIBUTION}-${DISTRO_VERSION}:${RUNTIME_VERSION}"
+      - echo "Extracting and including the Runtime Interface Emulator"
+      - SCRATCH_DIR=".scratch"
+      - mkdir "${SCRATCH_DIR}"
+      - tar -xvf test/integration/resources/aws-lambda-rie.tar.gz --directory "${SCRATCH_DIR}"
+      - >
+        cp "test/integration/docker/Dockerfile.programmatic.${OS_DISTRIBUTION}" \
+          "${SCRATCH_DIR}/Dockerfile.programmatic.${OS_DISTRIBUTION}.tmp"
+      - >
+        echo "RUN apk add curl" >> \
+          "${SCRATCH_DIR}/Dockerfile.programmatic.${OS_DISTRIBUTION}.tmp"
+      - >
+        echo "COPY ${SCRATCH_DIR}/aws-lambda-rie /usr/bin/aws-lambda-rie" >> \
+          "${SCRATCH_DIR}/Dockerfile.programmatic.${OS_DISTRIBUTION}.tmp"
+      - >
+        if [[ -z "${DOCKERHUB_USERNAME}" && -z "${DOCKERHUB_PASSWORD}" ]];
+        then
+            echo "DockerHub credentials not set as CodeBuild environment variables. Continuing without docker login."
+        else
+            echo "Performing DockerHub login . . ."
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+        fi
+      - echo "Building image ${IMAGE_TAG}"
+      - >
+        docker build . \
+          -f "${SCRATCH_DIR}/Dockerfile.programmatic.${OS_DISTRIBUTION}.tmp" \
+          -t "${IMAGE_TAG}" \
+          --build-arg RUNTIME_VERSION="${RUNTIME_VERSION}" \
+          --build-arg DISTRO_VERSION="${DISTRO_VERSION}"
+  build:
+    commands:
+      - set -x
+      - echo "Running Image ${IMAGE_TAG}"
+      - docker network create "${OS_DISTRIBUTION}-network"
+      - >
+        docker run \
+          --detach \
+          -e "NODE_BINARY_LOCATION=${NODE_BINARY_LOCATION}" \
+          --name "${OS_DISTRIBUTION}-app" \
+          --network "${OS_DISTRIBUTION}-network" \
+          --entrypoint="" \
+          "${IMAGE_TAG}" \
+          sh -c '/usr/bin/aws-lambda-rie ${NODE_BINARY_LOCATION} index.mjs'
+      - sleep 2
+      - >
+        docker run \
+          --name "${OS_DISTRIBUTION}-tester" \
+          --env "TARGET=${OS_DISTRIBUTION}-app" \
+          --network "${OS_DISTRIBUTION}-network" \
+          --entrypoint="" \
+          "${IMAGE_TAG}" \
+          sh -c 'curl -X POST "http://${TARGET}:8080/2015-03-31/functions/function/invocations" -d "{}" --max-time 10'
+      - actual="$(docker logs --tail 1 "${OS_DISTRIBUTION}-tester" | xargs)"
+      - expected='success'
+      - |
+        echo "Response: ${actual}"
+        if [[ "$actual" != "$expected" ]]; then
+          echo "fail! runtime: $RUNTIME - expected output $expected - got $actual"
+          echo "---------Container Logs: ${OS_DISTRIBUTION}-app----------"
+          echo
+          docker logs "${OS_DISTRIBUTION}-app"
+          echo
+          echo "---------------------------------------------------"
+          echo "--------Container Logs: ${OS_DISTRIBUTION}-tester--------"
+          echo
+          docker logs "${OS_DISTRIBUTION}-tester"
+          echo
+          echo "---------------------------------------------------"
+          exit -1
+        fi
+    finally:
+      - echo "Cleaning up..."
+      - docker stop "${OS_DISTRIBUTION}-app" || true
+      - docker rm --force "${OS_DISTRIBUTION}-app" || true
+      - docker stop "${OS_DISTRIBUTION}-tester" || true
+      - docker rm --force "${OS_DISTRIBUTION}-tester" || true
+      - docker network rm "${OS_DISTRIBUTION}-network" || true
+      - docker rmi "${IMAGE_TAG}" || true

--- a/test/integration/docker/Dockerfile.echo.alpine
+++ b/test/integration/docker/Dockerfile.echo.alpine
@@ -5,6 +5,8 @@ ARG DISTRO_VERSION
 
 # Stage 1 - build function and dependencies
 FROM node:${RUNTIME_VERSION}-alpine${DISTRO_VERSION} AS build-image
+# Include global arg in this stage of the build
+ARG DISTRO_VERSION
 # Install aws-lambda-cpp build dependencies
 RUN apk add --update-cache \
         build-base \
@@ -14,11 +16,20 @@ RUN apk add --update-cache \
         libffi-dev \
         autoconf \
         automake \
-        libexecinfo-dev \
         make \
         cmake \
         python3 \
         libcurl
+
+# AWS Lambda CPP and libcurl rely on backtrace which requires libexecinfo from Alpine.
+# Since starting from Alpine3.17 libexecinfo is no longer available, temporarily source it from Alpine3.16
+# while awaiting an upstream resolution in AWS Lambda CPP.
+RUN if [[ "${DISTRO_VERSION}" == "3.17" ]] || [[ "${DISTRO_VERSION}" == "3.18" ]] ; \
+then \
+    apk add --update-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.16/main/ libexecinfo-dev ; \
+else \
+    apk add --update-cache libexecinfo-dev ; \
+fi
 
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR

--- a/test/integration/docker/Dockerfile.programmatic.alpine
+++ b/test/integration/docker/Dockerfile.programmatic.alpine
@@ -5,6 +5,8 @@ ARG DISTRO_VERSION
 
 # Stage 1 - build function and dependencies
 FROM node:${RUNTIME_VERSION}-alpine${DISTRO_VERSION} AS build-image
+# Include global arg in this stage of the build
+ARG DISTRO_VERSION
 # Install aws-lambda-cpp build dependencies
 RUN apk add --update-cache \
         build-base \
@@ -14,11 +16,20 @@ RUN apk add --update-cache \
         libffi-dev \
         autoconf \
         automake \
-        libexecinfo-dev \
         make \
         cmake \
         python3 \
         libcurl
+
+# AWS Lambda CPP and libcurl rely on backtrace which requires libexecinfo from Alpine.
+# Since starting from Alpine3.17 libexecinfo is no longer available, temporarily source it from Alpine3.16
+# while awaiting an upstream resolution in AWS Lambda CPP.
+RUN if [[ "${DISTRO_VERSION}" == "3.17" ]] || [[ "${DISTRO_VERSION}" == "3.18" ]] ; \
+then \
+    apk add --update-cache --repository=https://dl-cdn.alpinelinux.org/alpine/v3.16/main/ libexecinfo-dev ; \
+else \
+    apk add --update-cache libexecinfo-dev ; \
+fi
 
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR


### PR DESCRIPTION
_Description of changes:_
* Onboard Alpine3.17 and Alpine 3.18 for integ tests
* Remove Alpine 3.15 for integ tests

_Target (OCI, Managed Runtime, both):_
OCI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
