### PR TITLE
Release aws-lambda-ric 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-ric",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-ric",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-ric",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "AWS Lambda Runtime Interface Client for NodeJs",
   "homepage": "https://github.com/aws/aws-lambda-nodejs-runtime-interface-client",
   "main": "dist/index.mjs",


### PR DESCRIPTION
_Description of changes:_

Release `aws-lambda-ric` 3.1.0

Changelog:
* https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/46
* https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/79
* https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/80
* https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/86
* https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/87


_Target (OCI, Managed Runtime, both):_
OCI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
