### PR TITLE
Handle invalid char when sending HTTP request to Runtime API

### DIFF
--- a/src/Errors.js
+++ b/src/Errors.js
@@ -38,9 +38,9 @@ function toRapidResponse(error) {
   try {
     if (util.types.isNativeError(error) || _isError(error)) {
       return {
-        errorType: error.name,
-        errorMessage: error.message,
-        trace: error.stack.split('\n'),
+        errorType: error.name?.replace(/\x7F/g, '%7F'),
+        errorMessage: error.message?.replace(/\x7F/g, '%7F'),
+        trace: error.stack.replace(/\x7F/g, '%7F').split('\n'),
       };
     } else {
       return {

--- a/src/XRayError.js
+++ b/src/XRayError.js
@@ -50,7 +50,7 @@ class XRayFormattedCause {
 
     let stack = [];
     if (err.stack) {
-      let stackLines = err.stack.split('\n');
+      let stackLines = err.stack.replace(/\x7F/g, '%7F').split('\n');
       stackLines.shift();
 
       stackLines.forEach((stackLine) => {
@@ -79,8 +79,8 @@ class XRayFormattedCause {
 
     this.exceptions = [
       {
-        type: err.name,
-        message: err.message,
+        type: err.name?.replace(/\x7F/g, '%7F'),
+        message: err.message?.replace(/\x7F/g, '%7F'),
         stack: stack,
       },
     ];

--- a/test/unit/ErrorsTest.js
+++ b/test/unit/ErrorsTest.js
@@ -19,3 +19,14 @@ describe('Formatted Error Logging', () => {
     loggedError.should.have.property('trace').with.length(11);
   });
 });
+
+describe('Invalid chars in HTTP header', () => {
+  it('should be replaced', () => {
+    let errorWithInvalidChar = new Error('\x7F \x7F');
+    errorWithInvalidChar.name = 'ErrorWithInvalidChar';
+
+    let loggedError = Errors.toRapidResponse(errorWithInvalidChar);
+    loggedError.should.have.property('errorType', 'ErrorWithInvalidChar');
+    loggedError.should.have.property('errorMessage', '%7F %7F');
+  });
+});


### PR DESCRIPTION
_Description of changes:_

Handle invalid `Delete` char `\x7F` when sending HTTP request to Runtime API by replacing it with `%7F`.

_Target (OCI, Managed Runtime, both):_
Both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
