### PR TITLE
Fix centos and ubuntu integ tests

### DIFF
--- a/test/integration/codebuild/buildspec.os.centos.yml
+++ b/test/integration/codebuild/buildspec.os.centos.yml
@@ -14,10 +14,8 @@ batch:
       env:
         variables:
           DISTRO_VERSION:
-            - "stream8"
             - "stream9"
           RUNTIME_VERSION:
-            - "16"
             - "18"
             - "20"
 phases:

--- a/test/integration/docker/Dockerfile.echo.centos
+++ b/test/integration/docker/Dockerfile.echo.centos
@@ -9,7 +9,7 @@ FROM quay.io/centos/centos:${DISTRO_VERSION} AS node-centos
 # Include global arg in this stage of the build
 ARG RUNTIME_VERSION
 # Install NodeJS
-RUN curl -sL https://rpm.nodesource.com/setup_${RUNTIME_VERSION}.x | bash - && \
+RUN yum module enable -y nodejs:${RUNTIME_VERSION} && \
     yum install -y nodejs
 
 

--- a/test/integration/docker/Dockerfile.echo.ubuntu
+++ b/test/integration/docker/Dockerfile.echo.ubuntu
@@ -34,7 +34,8 @@ RUN apt-get update && \
         automake \
         libtool \
         wget \
-        libcurl4-openssl-dev
+        libcurl4-openssl-dev \
+        python3
 # Install a modern CMake
 RUN wget --quiet -O cmake-install https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-${ARCHITECTURE}.sh && \
     sh cmake-install --skip-license --prefix=/usr --exclude-subdirectory;


### PR DESCRIPTION
_Description of changes:_
1. Fix centos and ubuntu integ tests.
2. Remove centos stream8 since it has reached EOL

_Target (OCI, Managed Runtime, both):_
OCI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
