### PR TITLE
Release aws-lambda-ric 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-ric",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-ric",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-ric",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "AWS Lambda Runtime Interface Client for NodeJs",
   "homepage": "https://github.com/aws/aws-lambda-nodejs-runtime-interface-client",
   "main": "dist/index.mjs",


### PR DESCRIPTION
_Description of changes:_

Changelog:

* Introduce advanced logging controls by @thenewguy39 in https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/91
* Bump package-lock deps by @andclt in https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/98
* Remove Node14 from integ tests matrix since it is deprecated by @andclt in https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/99
* Handle invalid char when sending HTTP request to Runtime API by @andclt in https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/100
* Update codebuild_build.sh script by @andclt in https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/110
* Fix centos and ubuntu integ tests by @andclt in https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/111
* Bump braces from 3.0.2 to 3.0.3 by @dependabot in https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/109
* Bump tar from 6.1.15 to 6.2.1 by @dependabot in https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/103
* Encode request id in URI path by @andclt in https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/pull/113

_Target (OCI, Managed Runtime, both):_
both

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
