### PR TITLE
Add module loading tests for user function

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,7 @@ _Description of changes:_
 
 _Target (OCI, Managed Runtime, both):_
 
+## Checklist
+- [ ] I have run `npm install` to generate the `package-lock.json` correctly and included it in the PR.
+
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ dist/
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+
+deps/artifacts/
+deps/aws-lambda-cpp*/
+deps/curl*/

--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ Then,
 * to run integration tests: `make test-integ`
 * to run smoke tests: `make test-smoke`
 
+### Raising a PR
+When modifying dependencies (`package.json`), make sure to:
+1. Run `npm install` to generate an updated `package-lock.json`
+2. Commit both `package.json` and `package-lock.json` together
+
+We require package-lock.json to be checked in to ensure consistent installations across development environments.
+
 ### Troubleshooting
 
 While running integration tests, you might encounter the Docker Hub rate limit error with the following body:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-ric",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-ric",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/test/handlers/extensionless/esm-extensionless
+++ b/test/handlers/extensionless/esm-extensionless
@@ -1,0 +1,6 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+// This should fail because it's ESM syntax in a CJS context
+export const handler = async (event) => {
+    return "This should fail";
+};

--- a/test/handlers/extensionless/index
+++ b/test/handlers/extensionless/index
@@ -1,0 +1,8 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+'use strict';
+// This is a CommonJS module without file extension
+
+module.exports.handler = async (event) => {
+    return "Hello from extensionless CJS";
+};

--- a/test/handlers/pkg-less/cjsAndMjs.js
+++ b/test/handlers/pkg-less/cjsAndMjs.js
@@ -1,0 +1,9 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+import { someESMFunction } from './esmModule.js';  // ESM import
+
+module.exports.handler = async (event) => {  // CJS export
+    return someESMFunction(event);
+};
+
+export const esm = 'This is ESM syntax';  // ESM export

--- a/test/handlers/pkg-less/cjsImportCjs.js
+++ b/test/handlers/pkg-less/cjsImportCjs.js
@@ -1,0 +1,9 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+'use strict';
+
+const { getMessage } = require('./cjsModule.cjs')
+
+exports.handler = async (_event) => {
+  return getMessage();
+}

--- a/test/handlers/pkg-less/cjsImportESM.cjs
+++ b/test/handlers/pkg-less/cjsImportESM.cjs
@@ -1,0 +1,10 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+'use strict';
+
+// This static import is not allowed in CJS
+import { getMessage } from './esmModule';
+
+module.exports.handler = async () => {
+    return getMessage();
+};

--- a/test/handlers/pkg-less/cjsInMjs.mjs
+++ b/test/handlers/pkg-less/cjsInMjs.mjs
@@ -1,0 +1,8 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+'use strict';
+
+// This should fail because it's CJS syntax in a ESM context
+module.exports.handler = async (_event) => {
+  return 'This should fail';
+};

--- a/test/handlers/pkg-less/cjsModule.cjs
+++ b/test/handlers/pkg-less/cjsModule.cjs
@@ -1,0 +1,7 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+'use strict';
+
+module.exports.getMessage = () => {
+    return "Hello from CJS!";
+};

--- a/test/handlers/pkg-less/esmImportCjs.mjs
+++ b/test/handlers/pkg-less/esmImportCjs.mjs
@@ -1,0 +1,7 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+import { getMessage } from './cjsModule.cjs';
+
+export const handler = async (_event) => {
+    return getMessage();
+};

--- a/test/handlers/pkg-less/esmInCjs.cjs
+++ b/test/handlers/pkg-less/esmInCjs.cjs
@@ -1,0 +1,6 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+// This should fail because it's ESM syntax in a CJS context
+export const handler = async (_event) => {
+  return 'This should fail';
+};

--- a/test/handlers/pkg-less/esmModule.js
+++ b/test/handlers/pkg-less/esmModule.js
@@ -1,0 +1,9 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+export const handler = async (_event) => {
+  return 'Hello from ESM.js';
+};
+
+export const getMessage = () => {
+  return "Hello from ESM!";
+};

--- a/test/handlers/pkg-less/esmRequireCjs.mjs
+++ b/test/handlers/pkg-less/esmRequireCjs.mjs
@@ -1,0 +1,7 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+const { getMessage } = require('./cjsModule.cjs')
+
+export const handler = async (_event) => {
+    return getMessage();
+};

--- a/test/handlers/pkg/type-cjs/cjs
+++ b/test/handlers/pkg/type-cjs/cjs
@@ -1,0 +1,8 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+'use strict';
+// This is a CommonJS module without file extension
+
+module.exports.handler = async (event) => {
+    return "Hello from extensionless CJS";
+};

--- a/test/handlers/pkg/type-cjs/cjsModule.js
+++ b/test/handlers/pkg/type-cjs/cjsModule.js
@@ -1,0 +1,7 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+'use strict';
+
+module.exports.handler = async (_event) => {
+  return 'Hello from CJS.js';
+};

--- a/test/handlers/pkg/type-cjs/esm
+++ b/test/handlers/pkg/type-cjs/esm
@@ -1,0 +1,6 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+// This should fail because it's ESM syntax in a CJS context
+export const handler = async (event) => {
+    return "This should fail";
+};

--- a/test/handlers/pkg/type-cjs/esmModule.js
+++ b/test/handlers/pkg/type-cjs/esmModule.js
@@ -1,0 +1,6 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+// This should fail because it's ESM syntax in a CJS context
+export const handler = async (_event) => {
+  return 'This should fail';
+};

--- a/test/handlers/pkg/type-cjs/package.json
+++ b/test/handlers/pkg/type-cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test/handlers/pkg/type-esm/cjs
+++ b/test/handlers/pkg/type-esm/cjs
@@ -1,0 +1,8 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+'use strict';
+// This is a CommonJS module without file extension
+
+module.exports.handler = async (event) => {
+    return "Hello from extensionless CJS";
+};

--- a/test/handlers/pkg/type-esm/cjsModule.js
+++ b/test/handlers/pkg/type-esm/cjsModule.js
@@ -1,0 +1,8 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+'use strict';
+
+// This should fail because it's CJS syntax in a ESM context
+module.exports.handler = async (_event) => {
+  return 'This should fail';
+};

--- a/test/handlers/pkg/type-esm/esm
+++ b/test/handlers/pkg/type-esm/esm
@@ -1,0 +1,6 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+// This should fail because it's ESM syntax in a CJS context
+export const handler = async (event) => {
+    return "This should fail";
+};

--- a/test/handlers/pkg/type-esm/esmModule.js
+++ b/test/handlers/pkg/type-esm/esmModule.js
@@ -1,0 +1,5 @@
+/** Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved. */
+
+export const handler = async (_event) => {
+  return 'Hello from ESM.js';
+};

--- a/test/handlers/pkg/type-esm/package.json
+++ b/test/handlers/pkg/type-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
_Description of changes:_
Add missing test scenarios:
- CJS in extensionless (with and without package.json) (failure and success)
- ESM in extensionless (with and without package.json) (failure and success)
- CJS in .js (with and without package.json) (failure and success)
- ESM in .js (with and without package.json) (failure and success)
- CJS + ESM in same context (explicit failure)
- CJS/ESM import/require combinations (failure and success)

## Checklist
- [x] I have run `npm install` to generate the `package-lock.json` correctly and included it in the PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
