### PR TITLE
fix: Add CLI binary entry point for aws-lambda-ric package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
   "name": "aws-lambda-ric",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-ric",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws/lambda-invoke-store": "0.2.2",
         "node-addon-api": "^8.3.1",
         "node-gyp": "^11.2.0"
+      },
+      "bin": {
+        "aws-lambda-ric": "index.mjs"
       },
       "devDependencies": {
         "@tsconfig/node22": "22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-ric",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "AWS Lambda Runtime Interface Client for Node.js",
   "license": "Apache-2.0",
   "repository": {
@@ -13,6 +13,9 @@
   },
   "type": "module",
   "main": "index.mjs",
+  "bin": {
+    "aws-lambda-ric": "./index.mjs"
+  },
   "scripts": {
     "preinstall": "./scripts/preinstall.sh",
     "postinstall": "./scripts/postinstall.sh",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,6 +11,9 @@ build({
   sourcemap: false,
   minify: false,
   outfile: OUT_FILE,
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
 })
   .then(() => {
     console.log("esbuild succeeded: output at", OUT_FILE);


### PR DESCRIPTION
_Issue #, if available:_ https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/issues/170

_Description of changes:_
Add CLI binary entry point for aws-lambda-ric package

_Target (OCI, Managed Runtime, both):_ OCI

## Checklist
- [x] I have run `npm install` to generate the `package-lock.json` correctly and included it in the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
