### PR TITLE
fix: remove autoreconf to prevent hang on ARM platforms (#121)

### DIFF
--- a/Dockerfile.native
+++ b/Dockerfile.native
@@ -32,8 +32,9 @@ RUN cd /tmp && \
 
 # Build curl
 WORKDIR /tmp/curl
-RUN autoreconf -fiv && \
-    CFLAGS="$CURL_CFLAGS" LDFLAGS="$CURL_LDFLAGS" ./configure \
+# Skip autoreconf - the curl tarball includes a pre-generated configure script
+# Running autoreconf hangs on ARM platforms due to bash/libtool/autoconf issue
+RUN CFLAGS="$CURL_CFLAGS" LDFLAGS="$CURL_LDFLAGS" ./configure \
         --prefix /build/deps \
         --disable-alt-svc \
         --disable-ares \

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -50,9 +50,12 @@ fi
 echo "Building curl..."
 (
     cd "$CURL_DIR"
-    # Only run autoreconf if configure doesn't exist or is older than configure.ac
-    if [ ! -f configure ] || [ configure.ac -nt configure ]; then
-        autoreconf -fiv
+    # The curl tarball includes a pre-generated configure script.
+    # We skip autoreconf as it hangs on ARM platforms due to a known
+    # bash/libtool/autoconf interaction issue.
+    if [ ! -f configure ]; then
+        echo "Error: configure script not found in curl archive" >&2
+        exit 1
     fi
     ./configure \
         --prefix "$ARTIFACTS_DIR" \


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

_Target (OCI, Managed Runtime, both):_

## Checklist
- [ ] I have run `npm install` to generate the `package-lock.json` correctly and included it in the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
