### PR TITLE
fix: default task root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aws-lambda-ric",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aws-lambda-ric",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1354,7 +1354,6 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1394,7 +1393,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1757,7 +1755,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2520,7 +2517,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2581,7 +2577,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4830,7 +4825,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4916,7 +4910,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5952,7 +5945,6 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6620,7 +6612,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-ric",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "AWS Lambda Runtime Interface Client for Node.js",
   "license": "Apache-2.0",
   "repository": {

--- a/src/utils/runtime-setup.test.ts
+++ b/src/utils/runtime-setup.test.ts
@@ -68,13 +68,15 @@ describe("runtime-setup", () => {
       );
     });
 
-    it("should throw if LAMBDA_TASK_ROOT is not set", async () => {
+    it("should fall back to process.cwd() when LAMBDA_TASK_ROOT is not set", async () => {
       // GIVEN
       delete process.env.LAMBDA_TASK_ROOT;
 
       // WHEN & THEN
-      await expect(createRuntime()).rejects.toThrow(
-        "LAMBDA_TASK_ROOT environment variable is not set",
+      await createRuntime();
+      expect(UserFunctionLoader.load).toHaveBeenCalledWith(
+        process.cwd(),
+        expect.any(String),
       );
     });
   });

--- a/src/utils/runtime-setup.ts
+++ b/src/utils/runtime-setup.ts
@@ -18,7 +18,12 @@ export async function createRuntime(
   const isMultiConcurrent = isMultiConcurrentMode();
   const runtimeApi = process.env.AWS_LAMBDA_RUNTIME_API;
   const handlerString = process.env._HANDLER;
-  const taskRoot = process.env.LAMBDA_TASK_ROOT;
+  // LAMBDA_TASK_ROOT is a restricted environment variable set to /var/task.
+  // If we set it as required we are forcing customers to set it to a value that
+  // can't change.
+  // We fall back to process.cwd() to allow OCI customers to place the handler wherever
+  // they want.
+  const taskRoot = process.env.LAMBDA_TASK_ROOT || process.cwd();
 
   if (!runtimeApi) {
     throw new PlatformError(
@@ -27,9 +32,6 @@ export async function createRuntime(
   }
   if (!handlerString) {
     throw new PlatformError("_HANDLER environment variable is not set");
-  }
-  if (!taskRoot) {
-    throw new PlatformError("LAMBDA_TASK_ROOT environment variable is not set");
   }
 
   const rapidClient = await RAPIDClient.create(


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Restore `LAMBDA_TASK_ROOT` fallback to `process.cwd()` for OCI runtime image customers.

The RIC 4.x refactoring introduced a hard requirement on the `LAMBDA_TASK_ROOT` environment variable, throwing a `PlatformError` when it's not set. This is a regression from `RIC 3.x` behavior where `process.cwd()` was used as the function root directory.

`LAMBDA_TASK_ROOT` is a restricted environment variable set by lambda worker environment to `/var/task`. Customers building custom runtime images via OCI cannot change this value, but were previously free to place their handler anywhere and rely on the working directory. The new strict check forces them to explicitly set `LAMBDA_TASK_ROOT`.


*Changes*
- Fall back to process.cwd() when LAMBDA_TASK_ROOT is not set, restoring RIC 3.x behavior
- Remove the now-unreachable PlatformError check for taskRoot (the fallback guarantees a value)
- Add unit test covering the fallback behavior

*Testing*
- Unit test verifying process.cwd() is used when LAMBDA_TASK_ROOT is unset
- Existing tests continue to pass

_Target (OCI, Managed Runtime, both):_ both


https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/issues/184

## Checklist
- [x] I have run `npm install` to generate the `package-lock.json` correctly and included it in the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
