### PR TITLE
fix: include tenant ID when logging with JSON format

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -67,6 +67,7 @@ export class Runtime {
       await this.runWithInvokeContext(
         context.awsRequestId,
         context.xRayTraceId,
+        context.tenantId,
         () => processor.processInvoke(context, event),
       );
     }
@@ -82,6 +83,7 @@ export class Runtime {
         await this.runWithInvokeContext(
           context.awsRequestId,
           context.xRayTraceId,
+          context.tenantId,
           () => processor.processInvoke(context, event),
         );
       });
@@ -91,6 +93,7 @@ export class Runtime {
   private async runWithInvokeContext(
     requestId: string,
     xRayTraceId: string | undefined,
+    tenantId: string | undefined,
     fn: () => Promise<void>,
   ): Promise<void> {
     const invokeStore = await InvokeStore.getInstanceAsync();
@@ -98,6 +101,7 @@ export class Runtime {
       {
         [InvokeStoreBase.PROTECTED_KEYS.REQUEST_ID]: requestId,
         [InvokeStoreBase.PROTECTED_KEYS.X_RAY_TRACE_ID]: xRayTraceId,
+        [InvokeStoreBase.PROTECTED_KEYS.TENANT_ID]: tenantId,
       },
       fn,
     );


### PR DESCRIPTION
_Description of changes:_

Updated Runtime to correctly set the request's tenant ID before executing the handler code

This fixes a bug where the tenant ID is not included in JSON log lines [as documented](https://docs.aws.amazon.com/lambda/latest/dg/tenant-isolation-monitor.html) 

_Target (OCI, Managed Runtime, both):_ 

Both

## Checklist
- [X] I have run `npm install` to generate the `package-lock.json` correctly and included it in the PR.

(There are no changes to dependencies)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
